### PR TITLE
Fixed Installation issues by specifying the dependent packages' version, and fixing imports.

### DIFF
--- a/QAOAKit/build_tables.py
+++ b/QAOAKit/build_tables.py
@@ -190,7 +190,7 @@ def build_full_qaoa_dataset():
             assert len(df_orig) == n_graphs[n_qubits]
             df_orig["n"] = df_orig.apply(lambda row: row["G"].number_of_nodes(), axis=1)
             assert (df_orig["n"] == n_qubits).all()
-            df = df.append(df_orig.reset_index())
+            df = pd.concat([df, df_orig.reset_index()], ignore_index=True)
     assert len(df) == sum(v * 3 for v in n_graphs.values())
     df.to_pickle(
         Path(build_tables_folder, "../data/lookup_tables/full_qaoa_dataset_table.p")

--- a/QAOAKit/qaoa.py
+++ b/QAOAKit/qaoa.py
@@ -1,7 +1,7 @@
 # QAOA circuit for MAXCUT
 
 import networkx as nx
-from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister, Aer, execute
+from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.compiler import transpile
 import numpy as np
 

--- a/QAOAKit/qiskit_interface.py
+++ b/QAOAKit/qiskit_interface.py
@@ -2,7 +2,7 @@ import numpy as np
 import networkx as nx
 from qiskit_optimization import QuadraticProgram
 from qiskit_optimization.algorithms import GoemansWilliamsonOptimizer
-from qiskit.algorithms.minimum_eigen_solvers.qaoa import QAOAAnsatz
+from qiskit.circuit.library import QAOAAnsatz
 
 from .utils import get_adjacency_matrix
 

--- a/QAOAKit/utils.py
+++ b/QAOAKit/utils.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 from functools import partial
-from qiskit.providers.aer import AerSimulator
+from qiskit_aer import AerSimulator
 import json
 import re
 import warnings
@@ -400,7 +400,7 @@ def load_results_file_into_dataframe(n_qubits, p):
             utils_folder,
             f"../data/qaoa-dataset-version1/Results/p={p}/n={n_qubits}_p={p}.txt",
         ),
-        delim_whitespace=True,
+        sep='\s+',
         names=colnames,
         header=None,
     )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 # read the contents of README file
 from os import path
@@ -18,22 +18,27 @@ setup(
     author_email="ruslan@shaydul.in",
     url="https://github.com/QAOAKit/QAOAKit",
     python_requires=">=3, <4",
-    packages=["QAOAKit"],
+    packages=find_packages("."),
     install_requires=[
-        "qiskit==0.29.0",
-        "pynauty",
-        "qiskit-optimization",
-        "pandas",
-        "networkx",
-        "numpy",
-        "pytest",
-        "tqdm",
-        "cvxgraphalgs",
-        "cvxopt",
-        "scikit-learn==1.0",
-        "notebook",
-        "matplotlib",
-        "seaborn",
+        # fixed version packages: high chance that using other versions might not work.
+        "qiskit==1.0.2",
+        "qiskit-aer==0.13.3",
+        "pynauty==1.1.2",
+        "scikit-learn==1.4.1.post1",
+        "qiskit-optimization==0.6.1",
+
+        # non-fixed version packages: may work with the latest release of these packages.
+        # Assiging version, to have a complete working setup for QAOAKit.
+        "pandas==2.2.1",
+        "networkx==3.2.1",
+        "numpy==1.26.4",
+        "pytest==8.1.1",
+        "tqdm==4.66.2",
+        "cvxgraphalgs==0.1.2",
+        "cvxopt==1.3.2",
+        "notebook==7.1.2",
+        "matplotlib==3.8.3",
+        "seaborn==0.13.2",
     ],
     zip_safe=True,
 )

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,8 +1,9 @@
 import networkx as nx
 import numpy as np
 import pandas as pd
-from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister, execute
-from qiskit.providers.aer import AerSimulator
+from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
+from qiskit.compiler import transpile
+from qiskit_aer import AerSimulator
 from functools import partial
 from pathlib import Path
 import copy
@@ -50,7 +51,7 @@ from QAOAKit.examples_utils import get_20_node_erdos_renyi_graphs
 from QAOAKit.parameter_optimization import get_median_pre_trained_kde
 
 from qiskit_optimization import QuadraticProgram
-from qiskit.algorithms.minimum_eigen_solvers.qaoa import QAOAAnsatz
+from qiskit.circuit.library import QAOAAnsatz
 
 test_utils_folder = Path(__file__).parent
 
@@ -406,11 +407,15 @@ def test_no_save_state():
     qc.measure(range(6), creg)
     qc.measure(qreg_ancilla, creg_ancilla)
 
-    counts = (
-        execute(qc, AerSimulator(), basis_gates=["u1", "u2", "u3", "cx"])
-        .result()
-        .get_counts()
-    )
+    # Transpile the circuit for the simulation backend
+    backend = AerSimulator()
+    transpiled_qc = transpile(qc, backend, basis_gates=["u1", "u2", "u3", "cx"])
+
+    # Run the circuit on the backend
+    job = backend.run(transpiled_qc)
+    counts = job.result().get_counts()
+    print(counts)
+    
     assert isinstance(counts, dict)
 
 


### PR DESCRIPTION
modified:

- `QAOAKit/build_tables.py`: Replaced `df.append` to `pd.concat`. `df.append` is deprecated
- `QAOAKit/qaoa.py`: Fixed imports
- `QAOAKit/qiskit_interface.py`: Fixed imports
- `QAOAKit/utils.py`: Fixed imports. Replaced `delim_whitespace` with `sep`. `delim_whitespace` is deprecated.
- `setup.py`: Fixed installation issues by fixing the versions of dependent packages.
- `test/test_utils.py`: Fixed imports. `qiskit.execute` is deprecated. Replaced with `transpile`.
  - `execute` is a wrapper for the `transpile` function. Hence the changes in the commit. It can be verified from [here](https://github.com/Qiskit/qiskit/blob/fb35b64e5f65bbd2790d2b46289b9ee174ce0cfb/qiskit/execute.py#L252).

> Note: some parts of the output of build_tables are not saved (index 9 is unloadable in [this](https://github.com/QAOAKit/QAOAKit/blob/4cbb6c0cc398c38fa97db40976de104618b4bb4a/QAOAKit/build_tables.py#L170) loop), because of which `get_full_qaoa_dataset_table` fails. Therefore test cases also fail that call this function. Will fix build_tables.py in a different PR.